### PR TITLE
Remove the "/" from img src attribute

### DIFF
--- a/html-practice.html
+++ b/html-practice.html
@@ -40,7 +40,7 @@
         without referring to the image itself. For example, do not write “Image of a Gidget the dog, Secret Life of
         Pets” but "Gidget the dog, Secret Life of Pets mascot."
     </p>
-    <img src="/images/gidget.png" alt="Gidget the dog, Secret Life of Pets mascot." width="200">
+    <img src="images/gidget.png" alt="Gidget the dog, Secret Life of Pets mascot." width="200">
     <br />
     <code>
         &lt;img src="gidget.png" alt="Gidget the dog, Secret Life of Pets mascot." width="200"/&gt; <br />

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
             <em>by Ludwig van Beethoven</em>
         </p>
         <p style="font-size: 20px; color: #00ffff;">
-            <a href="/about.html">About Us</a>
+            <a href="about.html">About Us</a>
         </p>
     </div>
     <!--Second section-->

--- a/index.html
+++ b/index.html
@@ -3,13 +3,13 @@
 
 <head>
     <title>Betina's HTML practice Website</title>
-    <link rel="shortcut icon" type="image/jpg" href="/images/compass.jpg" />
+    <link rel="shortcut icon" type="image/jpg" href="images/compass.jpg" />
     <meta charset="utf-8">
     <meta name="twitter:card" content="summary_large_image" /> <!--short summary with a large image preview-->
     <!--<meta name="twitter:site" content="@moonlightsonata" />-->
     <meta name="twitter:title" content="Moonlight Sonata" />
     <meta name="twitter:description" content="Moonlight Sonata, Piano Sonata No. 14 by Ludwig van Beethoven" />
-    <meta name="twitter:image" content="/images/piano.jpg" />
+    <meta name="twitter:image" content="images/piano.jpg" />
 
     <meta property="og:type" content="article" /> <!--Some type examples are article, book, and profile-->
     <meta property="og:title" content="Moonlight Sonata" />
@@ -22,9 +22,9 @@
 <body style="margin: 0;"> <!--Remove the margin surronding the page-->
     <!-- First section-->
     <div
-        style="background-image: url(/images/piano.jpg); background-size: cover ; width: 100%; padding-top: 30px; padding-bottom: 30px; text-align: center; ">
+        style="background-image: url(images/piano.jpg); background-size: cover ; width: 100%; padding-top: 30px; padding-bottom: 30px; text-align: center; ">
         <!--border-radius value to 50% gives the image a circular shape-->
-        <img src="/images/golden-treble-clef.jpg" style="height: 150px; border-radius: 50%; border: 4px solid #ffd700;"
+        <img src="images/golden-treble-clef.jpg" style="height: 150px; border-radius: 50%; border: 4px solid #ffd700;"
             alt="This is a small profile image of the Music page, a treble clef">
         <h1 style="font-size: 100px; color: #ffd700; margin: 10px;">Moonlight Sonata</h1>
         <h2 style="font-size: 50px; margin: 10px; color: #ffd700;">Piano Sonata No. 14</h2>
@@ -38,7 +38,7 @@
     <!--Second section-->
     <!--The float property allows to “float” the image to the right and left side of the display while allowing text to flow around its side.-->
     <div>
-        <img src="/images/moonlight-sonata.jpg" alt="Moonlight Sonata music sheet"
+        <img src="images/moonlight-sonata.jpg" alt="Moonlight Sonata music sheet"
             style="height: 800px; margin: 50px; float: left;">
     </div>
 


### PR DESCRIPTION
Quick fix to remove the "/" from the `img src=` attribute and from the "About Us" link, so as to render the images and the About Us page, on the GitHub Pages site.