### PR TITLE
Update image in metadata with canonical URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <title>Betina's HTML practice Website</title>
     <link rel="shortcut icon" type="image/jpg" href="images/compass.jpg" />
     <meta charset="utf-8">
+    <meta name="author" content="Betina Perez Neder">
     <meta name="twitter:card" content="summary_large_image" /> <!--short summary with a large image preview-->
     <!--<meta name="twitter:site" content="@moonlightsonata" />-->
     <meta name="twitter:title" content="Moonlight Sonata" />

--- a/index.html
+++ b/index.html
@@ -9,13 +9,13 @@
     <!--<meta name="twitter:site" content="@moonlightsonata" />-->
     <meta name="twitter:title" content="Moonlight Sonata" />
     <meta name="twitter:description" content="Moonlight Sonata, Piano Sonata No. 14 by Ludwig van Beethoven" />
-    <meta name="twitter:image" content="images/piano.jpg" />
+    <meta name="twitter:image" content="https://betinac.github.io/html-profile/images/piano.jpg" />
 
     <meta property="og:type" content="article" /> <!--Some type examples are article, book, and profile-->
     <meta property="og:title" content="Moonlight Sonata" />
     <meta property="og:description" content="Moonlight Sonata, Piano Sonata No. 14 by Ludwig van Beethoven" />
-    <meta property="og:url" content="https://somedomain.com/" /> <!--the permanent (canonical) URL of the page.-->
-    <meta property="og:image" content="https://somedomain.com/images/piano.jpg" />
+    <meta property="og:url" content="https://betinac.github.io/html-profile" /> <!--the permanent (canonical) URL of the page.-->
+    <meta property="og:image" content="https://betinac.github.io/html-profile/images/piano.jpg" />
     <!--an image to associate with the page-->
 </head>
 


### PR DESCRIPTION
Update urls on metadata now that we have the canonical version: `https://betinac.github.io/html-profile/images/`

# Checking social media cards based on metadata
Using the [Open Graph Debugger/ Simulator](https://en.rakko.tools/tools/9/)

## Facebook cards
![image](https://github.com/user-attachments/assets/0b102f0a-67f1-46da-90ba-aadd29728482)

## X (Twitter) cards
![image](https://github.com/user-attachments/assets/cb4ffd6b-22fe-4a26-9630-b51bdc7ed7c5)

## As a line
![image](https://github.com/user-attachments/assets/9f5e3d3f-9384-4fad-956e-fc07224513bb)
